### PR TITLE
Fix variable expansion: referencing local vars within vars

### DIFF
--- a/ansible_bender/constants.py
+++ b/ansible_bender/constants.py
@@ -1,6 +1,7 @@
 OUT_LOGGER = "ab-out"
 OUT_LOGGER_FORMAT = "%(message)s"
 TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S%f"
+TIMESTAMP_FORMAT_TOGETHER = "%Y%m%d%H%M%S%f"
 NO_CACHE_TAG = "no-cache"
 
 # configuration related constants

--- a/tests/data/full_conf_pb.yaml
+++ b/tests/data/full_conf_pb.yaml
@@ -22,7 +22,7 @@
         annotations:
           bohemian: rhapsody
         environment:
-          z: x
+          z: '{{ key }}'
         cmd: command -x -y z
         user: leonardo
 

--- a/tests/integration/test_conf.py
+++ b/tests/integration/test_conf.py
@@ -13,13 +13,13 @@ from tests.spellbook import b_p_w_vars_path, basic_playbook_path, full_conf_pb_p
 def test_expand_pb_vars():
     p = PbVarsParser(b_p_w_vars_path)
     data = p.expand_pb_vars()
-    assert data["ansible_bender"]["base_image"] == "docker.io/library/python:3-alpine"
-    assert data["ansible_bender"]["ansible_extra_args"] == "-vvv"
+    assert data["base_image"] == "docker.io/library/python:3-alpine"
+    assert data["ansible_extra_args"] == "-vvv"
     playbook_dir = os.path.dirname(b_p_w_vars_path)
-    assert data["ansible_bender"]["working_container"]["volumes"] == [f"{playbook_dir}:/src"]
-    assert data["ansible_bender"]["target_image"]["name"] == "challet"
-    assert data["ansible_bender"]["target_image"]["labels"] == {"x": "y"}
-    assert data["ansible_bender"]["target_image"]["environment"] == {"asd": playbook_dir}
+    assert data["working_container"]["volumes"] == [f"{playbook_dir}:/src"]
+    assert data["target_image"]["name"] == "challet"
+    assert data["target_image"]["labels"] == {"x": "y"}
+    assert data["target_image"]["environment"] == {"asd": playbook_dir}
 
 
 def test_b_m_empty():
@@ -59,7 +59,7 @@ def test_set_all_params():
     assert b.build_volumes == ["/c:/d"]
     assert b.target_image == "funky-mona-lisa"
 
-    assert m.env_vars == {"z": "x"}
+    assert m.env_vars == {"z": "value"}
     assert m.volumes == ["/a"]
     assert m.working_dir == "/workshop"
     assert m.labels == {"x": "y"}


### PR DESCRIPTION
```
10:28:07.579 utils.py          DEBUG  PLAY [Let Ansible expand variables] ***************************************************************************************************
**************************************
10:28:07.588 utils.py          DEBUG
10:28:07.588 utils.py          DEBUG  TASK [debug] **************************************************************************************************************************
**************************************
10:28:07.601 utils.py          DEBUG  fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'gopath' is undefined\n\
nThe error appears to have been in '/home/tt/g/TomasTomecek/ansible-bender/docs/.tmux-top-tests-20190316-102806578003-uaxhekgvyd.yaml': line 5, column 5, but may\nbe elsewhe
re in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n  - debug: {msg: '{{ ab_vars }}'}\n    ^ here\nWe could be wrong, but
 this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n
 - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
 10:28:07.602 utils.py          DEBUG
 10:28:07.602 utils.py          DEBUG  PLAY RECAP ****************************************************************************************************************************
 **************************************
 10:28:07.602 utils.py          DEBUG  localhost                  : ok=0    changed=0    unreachable=0    failed=1
 10:28:07.602 utils.py          DEBUG
 Traceback (most recent call last):
   File "/home/tt/.local/lib/python3.7/site-packages/ansible_bender/core.py", line 132, in run_playbook
       log_stderr=log_stderr,
         File "/home/tt/.local/lib/python3.7/site-packages/ansible_bender/utils.py", line 112, in run_cmd
             stderr=errout, output=out)
             subprocess.CalledProcessError: Command '['ansible-playbook', '-c', 'local', '-i', '/tmp/ab0nvv9g44/i', '-e', 'ansible_python_interpreter=/usr/bin/python3', '.tmux-top-tests-
             20190316-102806578003-uaxhekgvyd.yaml']' returned non-zero exit status 2.
```